### PR TITLE
[Misc] Exclude reactive-streams from mcp-json-jackson2 for XIP packaging

### DIFF
--- a/application-ai-llm-mcp/application-ai-llm-mcp-server/pom.xml
+++ b/application-ai-llm-mcp/application-ai-llm-mcp-server/pom.xml
@@ -169,6 +169,16 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <!-- mcp-json-jackson2 depends on mcp-core which depends on reactor-core which depends on
+                     reactive-streams:1.0.4. The XWiki platform ships reactive-streams:1.0.3 as a core
+                     extension. Exclude it here too (the mcp-core direct dependency already excludes it)
+                     so the XWiki extension resolver (used by XIP packaging) does not flag a version
+                     conflict with the core extension. reactor-core uses the platform-provided 1.0.3 at
+                     runtime. -->
+                <exclusion>
+                    <groupId>org.reactivestreams</groupId>
+                    <artifactId>reactive-streams</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Test dependencies -->


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Adds a `reactive-streams` exclusion to the `mcp-json-jackson2` dependency in `application-ai-llm-mcp-server/pom.xml`, mirroring the exclusion already present on the direct `mcp-core` dependency.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The `mcp-server` POM already excluded `org.reactivestreams:reactive-streams` from the direct `mcp-core` dependency, but not from the transitive path `mcp-json-jackson2 → mcp-core → reactor-core → reactive-streams:1.0.4`.
* Maven's dependency mediation handles this at compile time (the platform's `reactive-streams:1.0.3` wins via `provided` scope on the direct declaration), so regular builds and tests are unaffected.
* However, the **XWiki extension resolver** (used by the `xip` packaging lifecycle via `xwiki-commons-tool-extension-plugin`) resolves each POM's transitive dependency tree independently and rejects the install plan with:
  ```
  Dependency [org.reactivestreams:reactive-streams-1.0.4] is not compatible
  with core extension feature [org.reactivestreams:reactive-streams/1.0.3]
  ```
  because the XWiki WAR ships `reactive-streams:1.0.3` as a core extension, and `reactor-core:3.7.0` (pulled transitively via `mcp-json-jackson2 → mcp-core`) declares `reactive-streams:1.0.4`.
* This makes it impossible to build a self-contained XIP bundle of the MCP extension (e.g. for offline installation) without this fix.
* At runtime, `reactor-core` continues to use the platform-provided `reactive-streams:1.0.3`, exactly as it already does for the direct `mcp-core` dependency path. No runtime behavior changes.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A — no UI change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

* Verified the exclusion lets a minimal MCP-only XIP module build successfully:
  ```bash
  # Before the fix: XIP build fails with the "not compatible with core extension" error.
  # After the fix:
  cd application-ai-llm-mcp-xip   # a minimal xip module depending on mcp-ui
  mvn package -DskipTests \
    -Dxwiki.enforcer.skip=true \
    -Dxwiki.enforcer.valid-poms.skip=true \
    -Dxwiki.enforcer.no-legacy-dependencies.skip=true
  # → BUILD SUCCESS, produces application-ai-llm-mcp-xip-<version>.xip
  ```
* The resulting XIP correctly excludes `reactive-streams` (provided by the WAR) and bundles `reactor-core` + the MCP SDK + the three MCP modules (`mcp-ui`, `mcp-server`, `mcp-api`).
* No compile or test regressions — the change only affects XIP-time dependency resolution, not the compile classpath.



# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 